### PR TITLE
[IOT-543] Add support for Lambda Layers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ resource "aws_lambda_function" "default" {
   filename         = local.filename
   handler          = var.handler
   kms_key_arn      = var.kms_key_arn
+  layers           = var.layers
   memory_size      = var.memory_size
   runtime          = var.runtime
   role             = var.role_arn != null ? var.role_arn : aws_iam_role.default[0].arn

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "kms_key_arn" {
 variable "layers" {
   type        = list(string)
   default     = []
-  description = "List of Lambda Layer Arns to be used by the Lambda function"
+  description = "List of Lambda layer ARNs to be used by the Lambda function"
 }
 
 variable "memory_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,12 @@ variable "kms_key_arn" {
   description = "The ARN for the KMS key used to encrypt the environment variables"
 }
 
+variable "layers" {
+  type        = list(string)
+  default     = []
+  description = "List of Lambda Layer Arns to be used by the Lambda function"
+}
+
 variable "memory_size" {
   type        = number
   default     = null


### PR DESCRIPTION
Add support for [Lambda Layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) ([Terraform](https://www.terraform.io/docs/providers/aws/r/lambda_function.html#lambda-layers))