### PR TITLE
Fix filename/S3 configuration issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "aws_lambda_function_event_invoke_config" "default" {
 resource "aws_lambda_function" "default" {
   provider                       = aws.lambda
   description                    = var.description
-  filename                       = local.filename
+  filename                       = var.s3_bucket == null ? local.filename : null
   function_name                  = var.name
   handler                        = var.handler
   kms_key_arn                    = var.kms_key_arn


### PR DESCRIPTION
Fix the local filename: `local_filename` is `data.archive_file.dummy.output_path` if no filename is specified, so this breaks creating Lambda's with S3 (since S3 and filename are then always specified)

```
Error: "s3_bucket": conflicts with filename
  on .terraform/modules/usecase_o05a.material_quality_api/main.tf line 108, in resource "aws_lambda_function" "default":
 108: resource "aws_lambda_function" "default" {```