### PR TITLE
Upgrade to Terraform 0.15

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,67 @@
+---
+name: Terraform
+
+on:
+  pull_request:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Terraform Format
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: latest
+          tf_actions_subcommand: fmt
+          tf_actions_comment: true
+
+  terraform-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Terraform Init
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: latest
+          tf_actions_subcommand: init
+          tf_actions_comment: true
+      - name: Terraform Validate
+        uses: hashicorp/terraform-github-actions@master
+        env:
+          AWS_DEFAULT_REGION: eu-west-1
+        with:
+          tf_actions_version: latest
+          tf_actions_subcommand: validate
+          tf_actions_comment: true
+
+  terraform-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Update module usage docs and push any changes back to PR branch
+        uses: Dirrk/terraform-docs@v1.0.8
+        with:
+          tf_docs_args: '--sort-inputs-by-required'
+          tf_docs_git_commit_message: 'terraform-docs: Update module usage'
+          tf_docs_git_push: 'true'
+          tf_docs_output_file: README.md
+          tf_docs_output_method: inject
+          tf_docs_find_dir: .
+
+  tfsec:
+    name: tfsec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Terraform security scan
+        uses: triat/terraform-security-scan@v2.0.2

--- a/README.md
+++ b/README.md
@@ -1,58 +1,6 @@
 # terraform-aws-mcaf-lambda
 
 <!--- BEGIN_TF_DOCS --->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| terraform | >= 0.12.0 |
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| archive | n/a |
-| aws | n/a |
-| aws.lambda | n/a |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| name | The name of the lambda | `string` | n/a | yes |
-| tags | A mapping of tags to assign to the bucket | `map(string)` | n/a | yes |
-| cloudwatch\_logs | Whether or not to configure a CloudWatch log group | `bool` | `true` | no |
-| create\_policy | Overrule whether the Lambda role policy has to be created | `bool` | `null` | no |
-| description | A description of the lambda | `string` | `""` | no |
-| environment | A map of environment variables to assign to the lambda | `map(string)` | `null` | no |
-| filename | The path to the function's deployment package within the local filesystem | `string` | `null` | no |
-| handler | The function entrypoint in your code | `string` | `"main.handler"` | no |
-| kms\_key\_arn | The ARN for the KMS key used to encrypt the environment variables | `string` | `null` | no |
-| layers | List of Lambda layer ARNs to be used by the Lambda function | `list(string)` | `[]` | no |
-| log\_retention | Number of days to retain log events in the specified log group | `number` | `14` | no |
-| memory\_size | The memory size of the lambda | `number` | `null` | no |
-| policy | A valid lambda policy JSON document. Required if you don't specify a role\_arn | `string` | `null` | no |
-| publish | Whether to publish creation/change as new lambda function version | `bool` | `false` | no |
-| reserved\_concurrency | The amount of reserved concurrent executions for this lambda function | `number` | `null` | no |
-| retries | Maximum number of retries for the Lambda invocation | `number` | `null` | no |
-| role\_arn | An optional lambda execution role | `string` | `null` | no |
-| runtime | The function runtime to use | `string` | `"python3.7"` | no |
-| s3\_bucket | The S3 bucket location containing the function's deployment package | `string` | `null` | no |
-| s3\_key | The S3 key of an object containing the function's deployment package | `string` | `null` | no |
-| s3\_object\_version | The object version containing the function's deployment package | `string` | `null` | no |
-| subnet\_ids | The subnet ids where this lambda needs to run | `list(string)` | `null` | no |
-| timeout | The timeout of the lambda | `number` | `5` | no |
-| tracing\_config\_mode | The lambda's AWS X-Ray tracing configuration | `string` | `null` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| arn | ARN of the Lambda |
-| log\_group\_name | The Cloud Watch log group name |
-| name | Function name of the Lambda |
-| qualified\_arn | Qualified ARN of the Lambda |
-| security\_group\_id | If the Lambda is deployed into a VPC this will output the security group id |
-| version | Latest published version of the Lambda function |
+Error: Variables not allowed: Variables may not be used here.
 
 <!--- END_TF_DOCS --->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,58 @@
 # terraform-aws-mcaf-lambda
 
 <!--- BEGIN_TF_DOCS --->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| archive | n/a |
+| aws | n/a |
+| aws.lambda | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| name | The name of the lambda | `string` | n/a | yes |
+| tags | A mapping of tags to assign to the bucket | `map(string)` | n/a | yes |
+| cloudwatch\_logs | Whether or not to configure a CloudWatch log group | `bool` | `true` | no |
+| create\_policy | Overrule whether the Lambda role policy has to be created | `bool` | `null` | no |
+| description | A description of the lambda | `string` | `""` | no |
+| environment | A map of environment variables to assign to the lambda | `map(string)` | `null` | no |
+| filename | The path to the function's deployment package within the local filesystem | `string` | `null` | no |
+| handler | The function entrypoint in your code | `string` | `"main.handler"` | no |
+| kms\_key\_arn | The ARN for the KMS key used to encrypt the environment variables | `string` | `null` | no |
+| layers | List of Lambda layer ARNs to be used by the Lambda function | `list(string)` | `[]` | no |
+| log\_retention | Number of days to retain log events in the specified log group | `number` | `14` | no |
+| memory\_size | The memory size of the lambda | `number` | `null` | no |
+| policy | A valid lambda policy JSON document. Required if you don't specify a role\_arn | `string` | `null` | no |
+| publish | Whether to publish creation/change as new lambda function version | `bool` | `false` | no |
+| reserved\_concurrency | The amount of reserved concurrent executions for this lambda function | `number` | `null` | no |
+| retries | Maximum number of retries for the Lambda invocation | `number` | `null` | no |
+| role\_arn | An optional lambda execution role | `string` | `null` | no |
+| runtime | The function runtime to use | `string` | `"python3.7"` | no |
+| s3\_bucket | The S3 bucket location containing the function's deployment package | `string` | `null` | no |
+| s3\_key | The S3 key of an object containing the function's deployment package | `string` | `null` | no |
+| s3\_object\_version | The object version containing the function's deployment package | `string` | `null` | no |
+| subnet\_ids | The subnet ids where this lambda needs to run | `list(string)` | `null` | no |
+| timeout | The timeout of the lambda | `number` | `5` | no |
+| tracing\_config\_mode | The lambda's AWS X-Ray tracing configuration | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| arn | ARN of the Lambda |
+| log\_group\_name | The Cloud Watch log group name |
+| name | Function name of the Lambda |
+| qualified\_arn | Qualified ARN of the Lambda |
+| security\_group\_id | If the Lambda is deployed into a VPC this will output the security group id |
+| version | Latest published version of the Lambda function |
+
 <!--- END_TF_DOCS --->

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # terraform-aws-mcaf-lambda
+
+<!--- BEGIN_TF_DOCS --->
+<!--- END_TF_DOCS --->

--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "aws_security_group" "default" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:AWS009
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,6 @@ locals {
   vpc_config       = var.subnet_ids != null ? { create : true } : {}
 }
 
-provider "aws" {
-  alias = "lambda"
-}
-
 data "aws_iam_policy_document" "default" {
   statement {
     actions = [
@@ -125,7 +121,7 @@ resource "aws_lambda_function" "default" {
   timeout                        = var.timeout
   tags                           = var.tags
 
-  dynamic environment {
+  dynamic "environment" {
     for_each = local.environment
 
     content {
@@ -133,7 +129,7 @@ resource "aws_lambda_function" "default" {
     }
   }
 
-  dynamic tracing_config {
+  dynamic "tracing_config" {
     for_each = local.tracing_config
 
     content {
@@ -141,7 +137,7 @@ resource "aws_lambda_function" "default" {
     }
   }
 
-  dynamic vpc_config {
+  dynamic "vpc_config" {
     for_each = local.vpc_config
 
     content {

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "arn" {
   description = "ARN of the Lambda"
 }
 
+output "log_group_name" {
+  value       = var.cloudwatch_logs ? aws_cloudwatch_log_group.default[0].name : ""
+  description = "The Cloud Watch log group name"
+}
+
 output "name" {
   value       = aws_lambda_function.default.function_name
   description = "Function name of the Lambda"

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,10 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.lambda]
+    }
+  }
 }


### PR DESCRIPTION
This PR upgrades the module to support Terraform 0.15.

Also in this PR:

- Add validation on PR
- Add the Cloudwatch Loggroup name to the outputs