### PR TITLE
Removes the s3 dummy file

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,19 @@ data "archive_file" "dummy" {
   }
 }
 
+resource "aws_s3_bucket_object" "s3_dummy" {
+  count  = var.s3_dummy != false ? 1 : 0
+  bucket = var.s3_bucket
+  key    = var.s3_key
+  source = data.archive_file.dummy.output_path
+
+  lifecycle {
+    ignore_changes = [
+      source
+    ]
+  }
+}
+
 resource "aws_lambda_function_event_invoke_config" "default" {
   count                  = var.retries != null ? 1 : 0
   function_name          = aws_lambda_function.default.function_name
@@ -133,4 +146,7 @@ resource "aws_lambda_function" "default" {
       security_group_ids = [aws_security_group.default[0].id]
     }
   }
+  depends_on = [
+    aws_s3_bucket_object.s3_dummy
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -83,19 +83,6 @@ data "archive_file" "dummy" {
   }
 }
 
-resource "aws_s3_bucket_object" "s3_dummy" {
-  count  = var.s3_bucket != null && var.s3_key != null ? 1 : 0
-  bucket = var.s3_bucket
-  key    = var.s3_key
-  source = data.archive_file.dummy.output_path
-
-  lifecycle {
-    ignore_changes = [
-      source
-    ]
-  }
-}
-
 resource "aws_lambda_function_event_invoke_config" "default" {
   count                  = var.retries != null ? 1 : 0
   function_name          = aws_lambda_function.default.function_name

--- a/variables.tf
+++ b/variables.tf
@@ -145,3 +145,9 @@ variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the bucket"
 }
+
+variable "s3_dummy" {
+  type        = bool
+  default     = false
+  description = "Whether to use a dummy file when using a S3 object"
+}


### PR DESCRIPTION
A dummy file is not needed when using a S3 object as the source of the lambda function.
Terraform will deploy the package and will not recreate the function in case the key changes.

There are some workloads that need the creation of the s3 object before the function is created by terraform, so I added a boolean toggle called 's3_dummy'

This PR closes #33 
