### PR TITLE
Add `source_code_hash` variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
   environment      = var.environment != null ? { create : true } : {}
   execution_type   = var.subnet_ids == null ? "Basic" : "VPCAccess"
   filename         = var.filename != null ? var.filename : data.archive_file.dummy.output_path
-  source_code_hash = var.filename != null ? filebase64sha256(var.filename) : null
+  source_code_hash = var.source_code_hash != null ? var.source_code_hash : var.filename != null ? filebase64sha256(var.filename) : null
   tracing_config   = var.tracing_config_mode != null ? { create : true } : {}
   vpc_config       = var.subnet_ids != null ? { create : true } : {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,12 @@ variable "s3_object_version" {
   description = "The object version containing the function's deployment package"
 }
 
+variable "source_code_hash" {
+  type        = string
+  default     = null
+  description = "Optional source code hash"
+}
+
 variable "subnet_ids" {
   type        = list(string)
   default     = null


### PR DESCRIPTION
When using this module in combination with `data.archive_file` it fails because `filebase64sha256()` is called before the data resource is refreshed.

By using the `output_base64sha256` output from `data.archive_file` we get around this, but need a way to pass in this value, thus introduce the `source_code_hash` variable to optionally set the value and if not for the module to compute it.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
