### PR TITLE
Update module to Provider V4

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.0
+        uses: triat/terraform-security-scan@v3.0.1

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,7 @@ resource "aws_lambda_function_event_invoke_config" "default" {
   maximum_retry_attempts = var.retries
 }
 
+// tfsec:ignore:aws-lambda-enable-tracing
 resource "aws_lambda_function" "default" {
   provider                       = aws.lambda
   description                    = var.description

--- a/main.tf
+++ b/main.tf
@@ -85,11 +85,12 @@ data "archive_file" "dummy" {
   }
 }
 
-resource "aws_s3_bucket_object" "s3_dummy" {
+resource "aws_s3_object" "s3_dummy" {
   count  = var.s3_bucket != null && var.s3_key != null ? 1 : 0
   bucket = var.s3_bucket
   key    = var.s3_key
   source = data.archive_file.dummy.output_path
+  tags   = merge(var.tags, { "Lambda" = var.name })
 
   lifecycle {
     ignore_changes = [

--- a/variables.tf
+++ b/variables.tf
@@ -71,7 +71,7 @@ variable "memory_size" {
 
 variable "runtime" {
   type        = string
-  default     = "python3.7"
+  default     = "python3.9"
   description = "The function runtime to use"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,11 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = {
       source                = "hashicorp/aws"
       configuration_aliases = [aws.lambda]
+      version               = "> 4.0.0"
     }
   }
 }


### PR DESCRIPTION
This PR tweaks the code to make it compatible with the "new" V4 version of the AWS provider.

Change:
- Version explicitly set to` > 4.0.0`
- Changes `aws_s3_bucket_object ` to `aws_s3_object` (will recreate the object)

Tweaks:
- Changed the "default" runtime to the latest Python version: `python3.9`
- Added `tags` to the `aws_s3_object` dummy. Mainly done for insights (so it's clear where it comes from), so also added the Lambda name as a tag
- Updated `tf-sec` security check (old one broke) and suppressed the tracing warning. Low impact and it can be set with a variable