### PR TITLE
Add egress sg rule var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_security_group_rule" "allow_all_egress" {
-  count             = var.enable_all_egress_rule ? 1 : 0
+  count             = var.subnet_ids != null && var.enable_all_egress_rule ? 1 : 0
   description       = "Allow all outbound traffic to any IPv4 address"
   type              = "egress"
   from_port         = 0

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_security_group_rule" "allow_all_egress" {
-  count             = var.subnet_ids != null && var.enable_all_egress_rule ? 1 : 0
+  count             = var.subnet_ids != null && var.create_allow_all_egress_rule ? 1 : 0
   description       = "Allow all outbound traffic to any IPv4 address"
   type              = "egress"
   from_port         = 0

--- a/main.tf
+++ b/main.tf
@@ -65,14 +65,17 @@ resource "aws_security_group" "default" {
   description = "Security group for lambda ${var.name}"
   vpc_id      = data.aws_subnet.selected[0].vpc_id
   tags        = var.tags
+}
 
-  egress {
-    description = "All outbound traffic"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sg
-  }
+resource "aws_security_group_rule" "allow_all_egress" {
+  count             = var.enable_all_egress_rule ? 1 : 0
+  description       = "Allow all outbound traffic to any IPv4 address"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-vpc-no-public-egress-sg
+  security_group_id = aws_security_group.default.id
 }
 
 data "archive_file" "dummy" {

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "cloudwatch_logs" {
 variable "create_allow_all_egress_rule" {
   type        = bool
   default     = false
-  description = "If the lamba is deployed in a VPC by adding subnet_ids, this flag controls the creation of an all ports egress rule to the security group attached to the lambda"
+  description = "Controls whether an egress rule to any ipv4 address will be created when the lambda is configured to run in a VPC"
 }
 
 variable "create_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "dead_letter_target_arn" {
 variable "enable_all_egress_rule" {
   type        = bool
   default     = false
-  description = "A flag to enable/disable adding the all ports egress rule to the service security group"
+  description = "If the lamba is deployed in a VPC by adding subnet_ids, this flag controls the creation of an all ports egress rule to the security group attached to the lambda"
 }
 
 variable "environment" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "dead_letter_target_arn" {
   description = "The ARN of an SNS topic or SQS queue to notify when an invocation fails"
 }
 
+variable "enable_all_egress_rule" {
+  type        = bool
+  default     = false
+  description = "A flag to enable/disable adding the all ports egress rule to the service security group"
+}
+
 variable "environment" {
   type        = map(string)
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "cloudwatch_logs" {
   description = "Whether or not to configure a CloudWatch log group"
 }
 
+variable "create_allow_all_egress_rule" {
+  type        = bool
+  default     = false
+  description = "If the lamba is deployed in a VPC by adding subnet_ids, this flag controls the creation of an all ports egress rule to the security group attached to the lambda"
+}
+
 variable "create_policy" {
   type        = bool
   default     = null
@@ -25,12 +31,6 @@ variable "dead_letter_target_arn" {
   type        = string
   default     = null
   description = "The ARN of an SNS topic or SQS queue to notify when an invocation fails"
-}
-
-variable "enable_all_egress_rule" {
-  type        = bool
-  default     = false
-  description = "If the lamba is deployed in a VPC by adding subnet_ids, this flag controls the creation of an all ports egress rule to the security group attached to the lambda"
 }
 
 variable "environment" {


### PR DESCRIPTION
Currently the lambda function gets a default egress rule that allows all traffic. This causes findings in security hub and is difficult to explain in PCIDSS firewall reviews. This PR adds a variable to control the creation of the egress rule. By default this is off to set a secure default, but when this is enabled, the original behaviour is replicated. 