### PR TITLE
add empty egress and ingress inline definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,9 @@ resource "aws_security_group" "default" {
   description = "Security group for lambda ${var.name}"
   vpc_id      = data.aws_subnet.selected[0].vpc_id
   tags        = var.tags
+  
+  ingress = []
+  egress  = []
 }
 
 resource "aws_security_group_rule" "allow_all_egress" {

--- a/main.tf
+++ b/main.tf
@@ -63,11 +63,10 @@ resource "aws_security_group" "default" {
   count       = var.subnet_ids != null ? 1 : 0
   name        = var.name
   description = "Security group for lambda ${var.name}"
+  egress      = []
+  ingress     = []
   vpc_id      = data.aws_subnet.selected[0].vpc_id
   tags        = var.tags
-
-  ingress = []
-  egress  = []
 }
 
 resource "aws_security_group_rule" "allow_all_egress" {

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_security_group" "default" {
   description = "Security group for lambda ${var.name}"
   vpc_id      = data.aws_subnet.selected[0].vpc_id
   tags        = var.tags
-  
+
   ingress = []
   egress  = []
 }


### PR DESCRIPTION
Add an empty ingress and egress definition to remove existing security group rules that were previously created by inline rules. Now these are moved to external security group rule definitions to allow the egress to be enabled and disabled via a count. 