### PR TITLE
Revert "add empty egress and ingress inline definition"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,8 +63,6 @@ resource "aws_security_group" "default" {
   count       = var.subnet_ids != null ? 1 : 0
   name        = var.name
   description = "Security group for lambda ${var.name}"
-  egress      = []
-  ingress     = []
   vpc_id      = data.aws_subnet.selected[0].vpc_id
   tags        = var.tags
 }


### PR DESCRIPTION
Reverts schubergphilis/terraform-aws-mcaf-lambda#43

Hi @svanharmelen I made a mistake while testing this unfortunately. I just noticed that the inline ingress and egress definitions do remove the security group rules but also conflict in the same way they do when you set them. The rules are removed on one run and created on another run, and removed and created again. As I only ran one run on my test, this did not show, unfortunately. I don't think there is a solution to remove the previously created rules and at the same time manage them from outside the module. 

I propose the revert to the behaviour of the pervious version. That version worked as expected on new instantiations. On existing intantiations, the egress rule that allows all trafic should be removed from AWS manually.  I don't see another solution. Do you have an idea maybe? 