### PR TITLE
added variable create_s3_dummy_object_var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ data "archive_file" "dummy" {
 }
 
 resource "aws_s3_object" "s3_dummy" {
-  count  = var.s3_bucket != null && var.s3_key != null ? 1 : 0
+  count  = var.s3_bucket != null && var.s3_key != null && var.create_s3_dummy_object ? 1 : 0
   bucket = var.s3_bucket
   key    = var.s3_key
   source = data.archive_file.dummy.output_path

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "create_policy" {
   description = "Overrule whether the Lambda role policy has to be created"
 }
 
+variable "create_s3_dummy_object" {
+  type        = bool
+  default     = true
+  description = "Whether or not to create a S3 dummy object"
+}
+
 variable "dead_letter_target_arn" {
   type        = string
   default     = null


### PR DESCRIPTION
When using this module in combination with S3 bucket as deployment package source, a dummy artifact is created and uploaded to the S3 bucket. But this means it is not possible to reference an existing deployment package from S3 as this module overwrites it with the dummy artifact.

So added a variable create_s3_dummy_object which controls the creation of dummy artifact with default value set to true so the original behavior remains the same.