### PR TITLE
Update dependency flow of the default SG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,10 @@ resource "aws_security_group" "default" {
   description = "Security group for lambda ${var.name}"
   vpc_id      = data.aws_subnet.selected[0].vpc_id
   tags        = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "allow_all_egress" {


### PR DESCRIPTION
When unsetting the `subnet_ids` from a running Lambda it tries to delete the SG before updating the Lambda. As a result the SG cannot be deleted and TF runs fail.

This PR adds lifecycle configuration to change this behaviour with deletion, based on:

- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#change-of-name-or-name-prefix-value
- https://github.com/hashicorp/terraform-provider-aws/issues/10329#issuecomment-830697533
- https://github.com/hashicorp/terraform/issues/17614