### PR TITLE
Add support to specify the architecture

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,7 @@ resource "aws_lambda_function_event_invoke_config" "default" {
 // tfsec:ignore:aws-lambda-enable-tracing
 resource "aws_lambda_function" "default" {
   provider                       = aws.lambda
+  architectures                  = [var.architecture]
   description                    = var.description
   filename                       = var.s3_bucket == null ? local.filename : null
   function_name                  = var.name

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "architecture" {
 
   validation {
     condition     = contains(["arm64", "x86_64"], var.architecture)
-    error_message = "Allowed values for hnk_region are \"arm64\" or \"x86_64\"."
+    error_message = "Allowed values are \"arm64\" or \"x86_64\"."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,17 @@ variable "name" {
   description = "The name of the lambda"
 }
 
+variable "architecture" {
+  type        = string
+  default     = "x86_64"
+  description = "Instruction set architecture of the Lambda function"
+
+  validation {
+    condition     = contains(["arm64", "x86_64"], var.architecture)
+    error_message = "Allowed values for hnk_region are \"arm64\" or \"x86_64\"."
+  }
+}
+
 variable "description" {
   type        = string
   default     = ""


### PR DESCRIPTION
This PR adds the configuration of the Architecture of the Lambda.

Default is `x86_64`, setting it explicitly (what happens with this code) does not recreate/alter the Lambda, so this should be safe.

See also: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#architectures