### PR TITLE
Add (missing) tags to the Cloudwatch log group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,7 @@ resource "aws_cloudwatch_log_group" "default" {
   name              = "/aws/lambda/${var.name}"
   kms_key_id        = var.kms_key_arn
   retention_in_days = var.log_retention
+  tags              = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "default" {


### PR DESCRIPTION
This PR adds the (missing) tags to the Cloudwatch Log Group. Handy for cost insight.

Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#tags