### PR TITLE
breaking: remove explicit configuration alias

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,9 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source                = "hashicorp/aws"
-      configuration_aliases = [aws.lambda]
-      version               = "> 4.8.0"
+      source  = "hashicorp/aws"
+      version = "> 4.8.0"
     }
   }
 }


### PR DESCRIPTION
## what
- Remove explicit configuration alias

## why
- This removes the need to provide a `providers = { aws.lambda = aws }` argument for this module and any modules that depend on this module
- After this change, the provider will simply default to `aws` and if a different provider is needed, one can be provisioned like this.

```hcl
provider "aws" {
  region = "us-west-2"
}

provider "aws" {
  alias  = lambda
  region = "us-west-2"
}

module "lambda_securityhub_events_suppressor" {
  source                       = "github.com/schubergphilis/terraform-aws-mcaf-lambda?ref=v0.3.3"
  # current code with an aliased provider
  providers                    = { aws.lambda = aws.lambda }
  # current code with a non-aliased provider
  providers                    = { aws.lambda = aws }
  # after the proposed change with an aliased provider
  providers                    = { aws = aws.lambda }
  # after the proposed change with a non-aliased provider, simply remove "providers" to use the default "aws" provider

  # ...
}
```

## references
- For example, the `providers` argument can be removed from [suppressor.tf#L152-L155](https://github.com/schubergphilis/terraform-aws-mcaf-securityhub-findings-manager/blob/7027a792334d96beee0db667946a29256e28988a/suppressor.tf#L152-L155) after this change
