### PR TITLE
bug: Allows supplying the VPC ID to prevent it having to obtain it via data resource. This fixes the recreation of the SG because of that.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the bucket | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The timeout of the lambda | `number` | `5` | no |
 | <a name="input_tracing_config_mode"></a> [tracing\_config\_mode](#input\_tracing\_config\_mode) | The lambda's AWS X-Ray tracing configuration | `string` | `null` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID where this Lambda's SG is created. | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ locals {
   source_code_hash           = var.source_code_hash != null ? var.source_code_hash : var.filename != null ? filebase64sha256(var.filename) : null
   tracing_config             = var.tracing_config_mode != null ? { create : true } : {}
   vpc_config                 = var.subnet_ids != null ? { create : true } : {}
+  vpc_id                     = var.vpc_id != null ? var.vpc_id : data.aws_subnet.selected[0].vpc_id
 }
 
 data "aws_iam_policy_document" "default" {
@@ -77,7 +78,7 @@ resource "aws_security_group" "default" {
   name        = var.security_group_name_prefix == null ? var.name : null
   name_prefix = var.security_group_name_prefix != null ? var.security_group_name_prefix : null
   description = "Security group for lambda ${var.name}"
-  vpc_id      = data.aws_subnet.selected[0].vpc_id
+  vpc_id      = local.vpc_id
   tags        = var.tags
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -231,3 +231,9 @@ variable "tracing_config_mode" {
   default     = null
   description = "The lambda's AWS X-Ray tracing configuration"
 }
+
+variable "vpc_id" {
+  type        = string
+  default     = null
+  description = "The VPC ID where this Lambda's SG is created."
+}


### PR DESCRIPTION
Signed-off-by: Stefan Wessels Beljaars <swesselsbeljaars@schubergphilis.com>
