### PR TITLE
fix: Allow sourcecode hash also for s3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ repos:
         args:
           - --autofix
       - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials
       - id: detect-private-key
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.83.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: terraform_docs
       - id: terraform_validate
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 2.3.34
+    rev: 3.0.37
     hooks:
       - id: checkov
         verbose: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,6 @@ repos:
         args:
           - --autofix
       - id: detect-aws-credentials
-        args:
-          - --allow-missing-credentials
       - id: detect-private-key
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.83.5
@@ -25,7 +23,7 @@ repos:
       - id: terraform_docs
       - id: terraform_validate
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.0.37
+    rev: 2.3.34
     hooks:
       - id: checkov
         verbose: false

--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,7 @@ resource "aws_lambda_function" "default" {
   s3_bucket                      = var.s3_bucket
   s3_key                         = var.s3_key
   s3_object_version              = var.s3_object_version
-  source_code_hash               = var.s3_bucket == null ? local.source_code_hash : null
+  source_code_hash               = local.source_code_hash
   tags                           = var.tags
   timeout                        = var.timeout
 


### PR DESCRIPTION
By default the sourcecode_hash is used for local file deployments. 
But in some cases we want to update the lambda from terraform when using S3 files. This is supported by the sourcecode_hash

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#source_code_hash

When using this with s3_bucket and s3_key the module behaves as following:

source_code_hash = null -> no deployment when s3 file changes (previous behaviour)
source_code_hash = s3object.etag -> terraform will update function


Updated the Pre-commit to current versions and allow for no aws keys