### PR TITLE
bug: fixes creating role when no role_arn is specified 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   create_event_invoke_config = var.retries != null || var.destination_on_failure != null || var.destination_on_success != null ? { create : true } : {}
-  create_policy              = var.create_policy != null ? var.create_policy : var.role_arn == null
+  create_policy              = var.role_arn == null && (var.create_policy != null ? var.create_policy : true)
   dead_letter_config         = var.dead_letter_target_arn != null ? { create : true } : {}
   environment                = var.environment != null ? { create : true } : {}
   ephemeral_storage          = var.ephemeral_storage_size != null ? { create : true } : {}
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "default" {
 }
 
 resource "aws_iam_role" "default" {
-  count = local.create_policy ? 1 : 0
+  count = var.role_arn == null ? 1 : 0
 
   name                 = join("-", compact([var.role_prefix, "LambdaRole", var.name]))
   assume_role_policy   = data.aws_iam_policy_document.default.json
@@ -34,7 +34,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_iam_role_policy" "default" {
-  count = local.create_policy ? 1 : 0
+  count = local.create_policy && var.policy != null ? 1 : 0
 
   name   = "LambdaRole-${var.name}"
   role   = aws_iam_role.default[0].id


### PR DESCRIPTION
* fix trying to create a aws_iam_role_policy when no policy is given
* fix when role_arn is set, do not create a role in this module and create an empty role when create_policy is set to false

Signed-off-by: Stefan Wessels Beljaars <swesselsbeljaars@schubergphilis.com>
