### PR TITLE
bug: Fix no VPC SG checks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,6 @@ locals {
   source_code_hash           = var.source_code_hash != null ? var.source_code_hash : var.filename != null ? filebase64sha256(var.filename) : null
   tracing_config             = var.tracing_config_mode != null ? { create : true } : {}
   vpc_config                 = var.subnet_ids != null ? { create : true } : {}
-  security_group_ids         = length(var.security_group_ids) > 0 ? var.security_group_ids : [aws_security_group.default[0].id]
 }
 
 data "aws_iam_policy_document" "default" {
@@ -205,7 +204,7 @@ resource "aws_lambda_function" "default" {
 
     content {
       subnet_ids         = var.subnet_ids
-      security_group_ids = local.security_group_ids
+      security_group_ids = length(var.security_group_ids) > 0 ? var.security_group_ids : [aws_security_group.default[0].id]
     }
   }
 


### PR DESCRIPTION
This PR fixes a calculation bug when a Lambda without VPC is created. The check was "too early" in the `locals`. Since the local is used only once, just moved the calculation to the implementation part