### PR TITLE
breaking:  VPC configuration refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #  Local .terraform directories
 **/.terraform/*
+.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ No modules.
 | [aws_lambda_function_event_invoke_config.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_s3_object.s3_dummy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_vpc_security_group_egress_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [archive_file.dummy](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
@@ -75,14 +74,11 @@ No modules.
 | <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | The S3 bucket location containing the function's deployment package | `string` | `null` | no |
 | <a name="input_s3_key"></a> [s3\_key](#input\_s3\_key) | The S3 key of an object containing the function's deployment package | `string` | `null` | no |
 | <a name="input_s3_object_version"></a> [s3\_object\_version](#input\_s3\_object\_version) | The object version containing the function's deployment package | `string` | `null` | no |
-| <a name="input_security_group_egress_rules"></a> [security\_group\_egress\_rules](#input\_security\_group\_egress\_rules) | Security Group egress rules | <pre>list(object({<br>    cidr_ipv4                    = optional(string)<br>    cidr_ipv6                    = optional(string)<br>    description                  = string<br>    from_port                    = optional(number, 0)<br>    ip_protocol                  = optional(string, "-1")<br>    prefix_list_id               = optional(string)<br>    referenced_security_group_id = optional(string)<br>    to_port                      = optional(number, 0)<br>  }))</pre> | `[]` | no |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The security group(s) for running the Lambda within the VPC. If not specified a minimal default SG will be created | `list(string)` | `[]` | no |
-| <a name="input_security_group_name_prefix"></a> [security\_group\_name\_prefix](#input\_security\_group\_name\_prefix) | An optional prefix to create a unique name of the security group. If not provided `var.name` will be used | `string` | `null` | no |
 | <a name="input_source_code_hash"></a> [source\_code\_hash](#input\_source\_code\_hash) | Optional source code hash | `string` | `null` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The subnet ids where this lambda needs to run | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the bucket | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The timeout of the lambda | `number` | `5` | no |
 | <a name="input_tracing_config_mode"></a> [tracing\_config\_mode](#input\_tracing\_config\_mode) | The lambda's AWS X-Ray tracing configuration | `string` | `null` | no |
+| <a name="input_vpc_config"></a> [vpc\_config](#input\_vpc\_config) | The VPC configuration for Lambda function | <pre>object({<br>    ipv6_allowed_for_dual_stack = optional(bool, false)<br>    security_group_ids          = optional(list(string), [])<br>    security_group_name_prefix  = optional(string, null)<br>    subnet_ids                  = list(string)<br>  })</pre> | `null` | no |
 
 ## Outputs
 
@@ -93,7 +89,7 @@ No modules.
 | <a name="output_name"></a> [name](#output\_name) | Function name of the Lambda |
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | Qualified ARN of the Lambda |
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | ARN of the lambda execution role |
-| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | If the Lambda is deployed into a VPC this will output the genetered security group id (if no security groups are specified) |
+| <a name="output_security_group_ids"></a> [security\_group\_ids](#output\_security\_group\_ids) | Security groups associated with the Lambda |
 | <a name="output_version"></a> [version](#output\_version) | Latest published version of the Lambda function |
 <!-- END_TF_DOCS -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,9 +23,9 @@ output "role_arn" {
   description = "ARN of the lambda execution role"
 }
 
-output "security_group_id" {
-  value       = try(aws_security_group.default[0].id, "")
-  description = "If the Lambda is deployed into a VPC this will output the genetered security group id (if no security groups are specified)"
+output "security_group_ids" {
+  value       = length(try(var.vpc_config.security_group_ids, [])) > 0 ? var.vpc_config.security_group_ids : try(aws_security_group.default[0].id, [])
+  description = "Security groups associated with the Lambda"
 }
 
 output "version" {

--- a/variables.tf
+++ b/variables.tf
@@ -176,48 +176,10 @@ variable "s3_object_version" {
   description = "The object version containing the function's deployment package"
 }
 
-variable "security_group_ids" {
-  type        = list(string)
-  default     = []
-  description = "The security group(s) for running the Lambda within the VPC. If not specified a minimal default SG will be created"
-}
-
-variable "security_group_egress_rules" {
-  type = list(object({
-    cidr_ipv4                    = optional(string)
-    cidr_ipv6                    = optional(string)
-    description                  = string
-    from_port                    = optional(number, 0)
-    ip_protocol                  = optional(string, "-1")
-    prefix_list_id               = optional(string)
-    referenced_security_group_id = optional(string)
-    to_port                      = optional(number, 0)
-  }))
-  default     = []
-  description = "Security Group egress rules"
-
-  validation {
-    condition     = alltrue([for o in var.security_group_egress_rules : (o.cidr_ipv4 != null || o.cidr_ipv6 != null || o.prefix_list_id != null || o.referenced_security_group_id != null)])
-    error_message = "Although \"cidr_ipv4\", \"cidr_ipv6\", \"prefix_list_id\", and \"referenced_security_group_id\" are all marked as optional, you must provide one of them in order to configure the destination of the traffic."
-  }
-}
-
-variable "security_group_name_prefix" {
-  type        = string
-  default     = null
-  description = "An optional prefix to create a unique name of the security group. If not provided `var.name` will be used"
-}
-
 variable "source_code_hash" {
   type        = string
   default     = null
   description = "Optional source code hash"
-}
-
-variable "subnet_ids" {
-  type        = list(string)
-  default     = null
-  description = "The subnet ids where this lambda needs to run"
 }
 
 variable "tags" {
@@ -236,4 +198,15 @@ variable "tracing_config_mode" {
   type        = string
   default     = null
   description = "The lambda's AWS X-Ray tracing configuration"
+}
+
+variable "vpc_config" {
+  type = object({
+    ipv6_allowed_for_dual_stack = optional(bool, false)
+    security_group_ids          = optional(list(string), [])
+    security_group_name_prefix  = optional(string, null)
+    subnet_ids                  = list(string)
+  })
+  default     = null
+  description = "The VPC configuration for Lambda function"
 }


### PR DESCRIPTION
This PR refactors all the VPC related configuration in to a single `vpc_config` variable.

Currently the following variables are used for configuring a Lambda to run in a VPC:

- `subnet_ids`
- `security_group_name_prefix`
- `security_group_ids`
- `security_group_egress_rules`
 
This should improve/simplify usage of the module and also make it clearer what you need to do if you want to run it in a VPC: Set `vpc_config`.

Removed the `security_group_egress_rules` variable, thought is that passing your own SG is the way to go if you want to configure a Security Group.

Also added the (new) attribute `ipv6_allowed_for_dual_stack`.

If approved/ok I'll spend some time on the examples and writing it down in `Updrading.md`