### PR TITLE
bug: Simplify policy creation check to prevent deploy issues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_iam_role_policy" "default" {
-  count = local.create_policy && var.policy != null ? 1 : 0
+  count = local.create_policy ? 1 : 0
 
   name   = "LambdaRole-${var.name}"
   role   = aws_iam_role.default[0].id


### PR DESCRIPTION
The current check for the role creation is "too complex" for Terraform and causes issues with new deployments:

```Error: Invalid count argument on .terraform/modules/xxx/main.tf line 37, in resource "aws_iam_role_policy" "default":
  count = local.create_policy && var.policy != null ? 1 : 0
The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the resources that the count depends on.```

To make deployments possible again, this PR removed the `var.policy != null` part of the check. This might cause deploy time issues in situations where an invalid configuration is passed, but at least makes deployments of new Lambda's possible again.

This needs to refactoring in the future, but this is a hotfix for now