### PR TITLE
feature: Refactor role and policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,24 +22,21 @@ IMPORTANT: We do not pin modules to versions in our examples. We highly recommen
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_lambda_role"></a> [lambda\_role](#module\_lambda\_role) | github.com/schubergphilis/terraform-aws-mcaf-role | v0.3.3 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
-| [aws_iam_role.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.enable_xray_daemon_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_function_event_invoke_config.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config) | resource |
 | [aws_s3_object.s3_dummy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [archive_file.dummy](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [aws_iam_policy_document.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
@@ -65,7 +62,7 @@ No modules.
 | <a name="input_log_retention"></a> [log\_retention](#input\_log\_retention) | Number of days to retain log events in the specified log group | `number` | `365` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | The memory size of the lambda | `number` | `null` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The permissions boundary to set on the role | `string` | `null` | no |
-| <a name="input_policy"></a> [policy](#input\_policy) | A valid lambda policy JSON document. Required if you don't specify a role\_arn | `string` | `null` | no |
+| <a name="input_policy"></a> [policy](#input\_policy) | A valid lambda policy JSON document. This policy is used if you don't specify a role\_arn | `string` | `null` | no |
 | <a name="input_publish"></a> [publish](#input\_publish) | Whether to publish creation/change as new lambda function version | `bool` | `false` | no |
 | <a name="input_reserved_concurrency"></a> [reserved\_concurrency](#input\_reserved\_concurrency) | The amount of reserved concurrent executions for this lambda function | `number` | `null` | no |
 | <a name="input_retries"></a> [retries](#input\_retries) | Maximum number of retries for the Lambda invocation | `number` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ module "lambda_role" {
 
   source                = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.3"
   name                  = join("-", compact([var.role_prefix, "LambdaRole", var.name]))
-  create_policy         = true
+  create_policy         = var.create_policy
   permissions_boundary  = var.permissions_boundary
   postfix               = false
   principal_identifiers = ["edgelambda.amazonaws.com", "lambda.amazonaws.com"]

--- a/main.tf
+++ b/main.tf
@@ -190,23 +190,3 @@ resource "aws_lambda_function" "default" {
     }
   }
 }
-
-moved {
-  from = aws_iam_role_policy.default[0]
-  to   = module.lambda_role[0].aws_iam_role_policy.default[0]
-}
-
-moved {
-  from = aws_iam_role.default[0]
-  to   = module.lambda_role[0].aws_iam_role.default
-}
-
-moved {
-  from = aws_iam_role_policy_attachment.default[0]
-  to   = module.lambda_role[0].aws_iam_role_policy_attachment.default["arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"]
-}
-
-moved {
-  from = aws_iam_role_policy_attachment.enable_xray_daemon_write[0]
-  to   = module.lambda_role[0].aws_iam_role_policy_attachment.default["arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"]
-}

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,19 @@
+moved {
+  from = aws_iam_role_policy.default[0]
+  to   = module.lambda_role[0].aws_iam_role_policy.default[0]
+}
+
+moved {
+  from = aws_iam_role.default[0]
+  to   = module.lambda_role[0].aws_iam_role.default
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.default[0]
+  to   = module.lambda_role[0].aws_iam_role_policy_attachment.default["arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.enable_xray_daemon_write[0]
+  to   = module.lambda_role[0].aws_iam_role_policy_attachment.default["arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,7 +19,7 @@ output "qualified_arn" {
 }
 
 output "role_arn" {
-  value       = var.role_arn != null ? var.role_arn : aws_iam_role.default[0].arn
+  value       = var.role_arn != null ? var.role_arn : module.lambda_role[0].arn
   description = "ARN of the lambda execution role"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "code_signing_config_arn" {
   description = "ARN for a Code Signing Configuration"
 }
 
+variable "create_policy" {
+  type        = bool
+  default     = null
+  description = "Overrule whether the Lambda role policy has to be created"
+}
+
 variable "create_s3_dummy_object" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -21,12 +21,6 @@ variable "code_signing_config_arn" {
   description = "ARN for a Code Signing Configuration"
 }
 
-variable "create_policy" {
-  type        = bool
-  default     = null
-  description = "Overrule whether the Lambda role policy has to be created"
-}
-
 variable "create_s3_dummy_object" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -119,7 +119,7 @@ variable "permissions_boundary" {
 variable "policy" {
   type        = string
   default     = null
-  description = "A valid lambda policy JSON document. Required if you don't specify a role_arn"
+  description = "A valid lambda policy JSON document. This policy is used if you don't specify a role_arn"
 }
 
 variable "publish" {


### PR DESCRIPTION
This PR refactors all the logic and complexity of creating roles and policies by replacing it with the mcaf-role module.

Unfortunately the `create_policy` boolean is still needed since TF doesn't like the `var.string !== null` checks


