### PR TITLE
fix: Fix the check on given RoleArn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 module "lambda_role" {
-  count = length([var.role_arn]) == 0 ? 1 : 0
+  count = length(compact([var.role_arn])) == 0 ? 1 : 0
 
   source                = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.3"
   name                  = join("-", compact([var.role_prefix, "LambdaRole", var.name]))
@@ -140,7 +140,7 @@ resource "aws_lambda_function" "default" {
   memory_size                    = var.memory_size
   publish                        = var.publish
   reserved_concurrent_executions = var.reserved_concurrency
-  role                           = length([var.role_arn]) > 0 ? var.role_arn : module.lambda_role[0].arn
+  role                           = length(compact([var.role_arn])) > 0 ? var.role_arn : module.lambda_role[0].arn
   runtime                        = var.runtime
   s3_bucket                      = var.s3_bucket
   s3_key                         = var.s3_key

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,7 +19,7 @@ output "qualified_arn" {
 }
 
 output "role_arn" {
-  value       = length([var.role_arn]) > 0 ? var.role_arn : module.lambda_role[0].arn
+  value       = length(compact([var.role_arn])) > 0 ? var.role_arn : module.lambda_role[0].arn
   description = "ARN of the lambda execution role"
 }
 


### PR DESCRIPTION
This PR fixes the "Is a roleArn given?" check.


The length workaround introduced in https://github.com/schubergphilis/terraform-aws-mcaf-lambda/releases/tag/v1.4.0 is not sufficient, even is `null` is given the `length([null])` check will return 1. The fix is using the `compact` function, which removes null values from a list ([source](https://developer.hashicorp.com/terraform/language/functions/compact))