### PR TITLE
fix: create_policy is required in some situations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Terraform module to create an AWS Lambda function.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.92.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.76.0 |
 
 ## Modules
 
@@ -47,6 +47,7 @@ Terraform module to create an AWS Lambda function.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | The name of the lambda | `string` | n/a | yes |
 | <a name="input_architecture"></a> [architecture](#input\_architecture) | Instruction set architecture of the Lambda function | `string` | `"x86_64"` | no |
 | <a name="input_cloudwatch_logs"></a> [cloudwatch\_logs](#input\_cloudwatch\_logs) | Whether or not to configure a CloudWatch log group | `bool` | `true` | no |
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | ARN for a Code Signing Configuration | `string` | `null` | no |
@@ -67,7 +68,6 @@ Terraform module to create an AWS Lambda function.
 | <a name="input_layers"></a> [layers](#input\_layers) | List of Lambda layer ARNs to be used by the Lambda function | `list(string)` | `[]` | no |
 | <a name="input_log_retention"></a> [log\_retention](#input\_log\_retention) | Number of days to retain log events in the specified log group | `number` | `365` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | The memory size of the lambda | `number` | `null` | no |
-| <a name="input_name"></a> [name](#input\_name) | The name of the lambda | `string` | n/a | yes |
 | <a name="input_package_type"></a> [package\_type](#input\_package\_type) | The Lambda deployment package type. | `string` | `"Zip"` | no |
 | <a name="input_publish"></a> [publish](#input\_publish) | Whether to publish creation/change as new lambda function version | `bool` | `false` | no |
 | <a name="input_reserved_concurrency"></a> [reserved\_concurrency](#input\_reserved\_concurrency) | The amount of reserved concurrent executions for this lambda function | `number` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Terraform module to create an AWS Lambda function.
 | <a name="input_architecture"></a> [architecture](#input\_architecture) | Instruction set architecture of the Lambda function | `string` | `"x86_64"` | no |
 | <a name="input_cloudwatch_logs"></a> [cloudwatch\_logs](#input\_cloudwatch\_logs) | Whether or not to configure a CloudWatch log group | `bool` | `true` | no |
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | ARN for a Code Signing Configuration | `string` | `null` | no |
-| <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | Overrule whether the Lambda role policy has to be created | `bool` | `null` | no |
 | <a name="input_create_s3_dummy_object"></a> [create\_s3\_dummy\_object](#input\_create\_s3\_dummy\_object) | Whether or not to create a S3 dummy object | `bool` | `true` | no |
 | <a name="input_dead_letter_target_arn"></a> [dead\_letter\_target\_arn](#input\_dead\_letter\_target\_arn) | The ARN of an SNS topic or SQS queue to notify when an invocation fails | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | A description of the lambda | `string` | `""` | no |
@@ -59,7 +58,7 @@ Terraform module to create an AWS Lambda function.
 | <a name="input_destination_on_success"></a> [destination\_on\_success](#input\_destination\_on\_success) | ARN of the destination resource for successful asynchronous invocations | `string` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | A map of environment variables to assign to the lambda | `map(string)` | `null` | no |
 | <a name="input_ephemeral_storage_size"></a> [ephemeral\_storage\_size](#input\_ephemeral\_storage\_size) | The size of the Lambda function Ephemeral storage | `number` | `null` | no |
-| <a name="input_execution_role"></a> [execution\_role](#input\_execution\_role) | Configuration for lambda execution IAM role | <pre>object({<br/>    additional_policy_arns = optional(set(string), [])<br/>    name_prefix            = optional(string)<br/>    path                   = optional(string, "/")<br/>    permissions_boundary   = optional(string)<br/>    policy                 = optional(string)<br/>  })</pre> | `{}` | no |
+| <a name="input_execution_role"></a> [execution\_role](#input\_execution\_role) | Configuration for lambda execution IAM role | <pre>object({<br/>    additional_policy_arns = optional(set(string), [])<br/>    create_policy          = optional(bool)<br/>    name_prefix            = optional(string)<br/>    path                   = optional(string, "/")<br/>    permissions_boundary   = optional(string)<br/>    policy                 = optional(string)<br/>  })</pre> | `{}` | no |
 | <a name="input_execution_role_custom"></a> [execution\_role\_custom](#input\_execution\_role\_custom) | Optional existing IAM role for Lambda execution. Overrides the role configured in the execution\_role variable. | <pre>object({<br/>    arn = string<br/>  })</pre> | `null` | no |
 | <a name="input_filename"></a> [filename](#input\_filename) | The path to the function's deployment package within the local filesystem | `string` | `null` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | The function entrypoint in your code | `string` | `"main.handler"` | no |

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Terraform module to create an AWS Lambda function.
 
-> [!TIP] 
+> [!TIP]
 > We do not pin modules to versions in our examples. We highly recommend that in your code you pin the version to the exact version you are using so that your infrastructure remains stable.
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > Exactly one of `var.filename`, `var.image_config.uri`, or `var.s3_bucket` must be specified when using the module.
 
 <!-- BEGIN_TF_DOCS -->
@@ -15,14 +15,14 @@ Terraform module to create an AWS Lambda function.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.76.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.92.0 |
 
 ## Modules
 
@@ -47,10 +47,10 @@ Terraform module to create an AWS Lambda function.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_name"></a> [name](#input\_name) | The name of the lambda | `string` | n/a | yes |
 | <a name="input_architecture"></a> [architecture](#input\_architecture) | Instruction set architecture of the Lambda function | `string` | `"x86_64"` | no |
 | <a name="input_cloudwatch_logs"></a> [cloudwatch\_logs](#input\_cloudwatch\_logs) | Whether or not to configure a CloudWatch log group | `bool` | `true` | no |
 | <a name="input_code_signing_config_arn"></a> [code\_signing\_config\_arn](#input\_code\_signing\_config\_arn) | ARN for a Code Signing Configuration | `string` | `null` | no |
+| <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | Overrule whether the Lambda role policy has to be created | `bool` | `null` | no |
 | <a name="input_create_s3_dummy_object"></a> [create\_s3\_dummy\_object](#input\_create\_s3\_dummy\_object) | Whether or not to create a S3 dummy object | `bool` | `true` | no |
 | <a name="input_dead_letter_target_arn"></a> [dead\_letter\_target\_arn](#input\_dead\_letter\_target\_arn) | The ARN of an SNS topic or SQS queue to notify when an invocation fails | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | A description of the lambda | `string` | `""` | no |
@@ -58,15 +58,16 @@ Terraform module to create an AWS Lambda function.
 | <a name="input_destination_on_success"></a> [destination\_on\_success](#input\_destination\_on\_success) | ARN of the destination resource for successful asynchronous invocations | `string` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | A map of environment variables to assign to the lambda | `map(string)` | `null` | no |
 | <a name="input_ephemeral_storage_size"></a> [ephemeral\_storage\_size](#input\_ephemeral\_storage\_size) | The size of the Lambda function Ephemeral storage | `number` | `null` | no |
-| <a name="input_execution_role"></a> [execution\_role](#input\_execution\_role) | Configuration for lambda execution IAM role | <pre>object({<br>    additional_policy_arns = optional(set(string), [])<br>    name_prefix            = optional(string)<br>    path                   = optional(string, "/")<br>    permissions_boundary   = optional(string)<br>    policy                 = optional(string)<br>  })</pre> | `{}` | no |
-| <a name="input_execution_role_custom"></a> [execution\_role\_custom](#input\_execution\_role\_custom) | Optional existing IAM role for Lambda execution. Overrides the role configured in the execution\_role variable. | <pre>object({<br>    arn = string<br>  })</pre> | `null` | no |
+| <a name="input_execution_role"></a> [execution\_role](#input\_execution\_role) | Configuration for lambda execution IAM role | <pre>object({<br/>    additional_policy_arns = optional(set(string), [])<br/>    name_prefix            = optional(string)<br/>    path                   = optional(string, "/")<br/>    permissions_boundary   = optional(string)<br/>    policy                 = optional(string)<br/>  })</pre> | `{}` | no |
+| <a name="input_execution_role_custom"></a> [execution\_role\_custom](#input\_execution\_role\_custom) | Optional existing IAM role for Lambda execution. Overrides the role configured in the execution\_role variable. | <pre>object({<br/>    arn = string<br/>  })</pre> | `null` | no |
 | <a name="input_filename"></a> [filename](#input\_filename) | The path to the function's deployment package within the local filesystem | `string` | `null` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | The function entrypoint in your code | `string` | `"main.handler"` | no |
-| <a name="input_image_config"></a> [image\_config](#input\_image\_config) | Container image configuration values. The ECR image URI must be a private ECR URI. | <pre>object({<br>    command           = optional(list(string), [])<br>    entry_point       = optional(list(string), [])<br>    uri               = optional(string)<br>    working_directory = optional(string)<br>  })</pre> | `null` | no |
+| <a name="input_image_config"></a> [image\_config](#input\_image\_config) | Container image configuration values. The ECR image URI must be a private ECR URI. | <pre>object({<br/>    command           = optional(list(string), [])<br/>    entry_point       = optional(list(string), [])<br/>    uri               = optional(string)<br/>    working_directory = optional(string)<br/>  })</pre> | `null` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key used to encrypt the cloudwatch log group and environment variables | `string` | `null` | no |
 | <a name="input_layers"></a> [layers](#input\_layers) | List of Lambda layer ARNs to be used by the Lambda function | `list(string)` | `[]` | no |
 | <a name="input_log_retention"></a> [log\_retention](#input\_log\_retention) | Number of days to retain log events in the specified log group | `number` | `365` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | The memory size of the lambda | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the lambda | `string` | n/a | yes |
 | <a name="input_package_type"></a> [package\_type](#input\_package\_type) | The Lambda deployment package type. | `string` | `"Zip"` | no |
 | <a name="input_publish"></a> [publish](#input\_publish) | Whether to publish creation/change as new lambda function version | `bool` | `false` | no |
 | <a name="input_reserved_concurrency"></a> [reserved\_concurrency](#input\_reserved\_concurrency) | The amount of reserved concurrent executions for this lambda function | `number` | `null` | no |
@@ -75,7 +76,7 @@ Terraform module to create an AWS Lambda function.
 | <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | The S3 bucket location containing the function's deployment package | `string` | `null` | no |
 | <a name="input_s3_key"></a> [s3\_key](#input\_s3\_key) | The S3 key of an object containing the function's deployment package | `string` | `null` | no |
 | <a name="input_s3_object_version"></a> [s3\_object\_version](#input\_s3\_object\_version) | The object version containing the function's deployment package | `string` | `null` | no |
-| <a name="input_security_group_egress_rules"></a> [security\_group\_egress\_rules](#input\_security\_group\_egress\_rules) | Security Group egress rules | <pre>list(object({<br>    cidr_ipv4                    = optional(string)<br>    cidr_ipv6                    = optional(string)<br>    description                  = string<br>    from_port                    = optional(number, 0)<br>    ip_protocol                  = optional(string, "-1")<br>    prefix_list_id               = optional(string)<br>    referenced_security_group_id = optional(string)<br>    to_port                      = optional(number, 0)<br>  }))</pre> | `[]` | no |
+| <a name="input_security_group_egress_rules"></a> [security\_group\_egress\_rules](#input\_security\_group\_egress\_rules) | Security Group egress rules | <pre>list(object({<br/>    cidr_ipv4                    = optional(string)<br/>    cidr_ipv6                    = optional(string)<br/>    description                  = string<br/>    from_port                    = optional(number, 0)<br/>    ip_protocol                  = optional(string, "-1")<br/>    prefix_list_id               = optional(string)<br/>    referenced_security_group_id = optional(string)<br/>    to_port                      = optional(number, 0)<br/>  }))</pre> | `[]` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The security group(s) for running the Lambda within the VPC. If not specified a minimal default SG will be created | `list(string)` | `[]` | no |
 | <a name="input_security_group_name_prefix"></a> [security\_group\_name\_prefix](#input\_security\_group\_name\_prefix) | An optional prefix to create a unique name of the security group. If not provided `var.name` will be used | `string` | `null` | no |
 | <a name="input_source_code_hash"></a> [source\_code\_hash](#input\_source\_code\_hash) | Optional source code hash | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ module "lambda_role" {
   source  = "schubergphilis/mcaf-role/aws"
   version = "~> 0.4.0"
 
+  create_policy         = var.execution_role.create_policy
   name                  = join("-", compact([var.execution_role.name_prefix, "LambdaRole", var.name]))
   path                  = var.execution_role.path
   permissions_boundary  = var.execution_role.permissions_boundary
@@ -24,7 +25,6 @@ module "lambda_role" {
   principal_identifiers = ["edgelambda.amazonaws.com", "lambda.amazonaws.com"]
   principal_type        = "Service"
   role_policy           = var.execution_role.policy
-  create_policy         = var.create_policy
   tags                  = var.tags
 
   policy_arns = setunion(compact([

--- a/main.tf
+++ b/main.tf
@@ -17,8 +17,8 @@ module "lambda_role" {
   source  = "schubergphilis/mcaf-role/aws"
   version = "~> 0.4.0"
 
-  create_policy         = var.execution_role.create_policy
   name                  = join("-", compact([var.execution_role.name_prefix, "LambdaRole", var.name]))
+  create_policy         = var.execution_role.create_policy
   path                  = var.execution_role.path
   permissions_boundary  = var.execution_role.permissions_boundary
   postfix               = false

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "lambda_role" {
   principal_identifiers = ["edgelambda.amazonaws.com", "lambda.amazonaws.com"]
   principal_type        = "Service"
   role_policy           = var.execution_role.policy
+  create_policy         = var.create_policy
   tags                  = var.tags
 
   policy_arns = setunion(compact([

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "code_signing_config_arn" {
   description = "ARN for a Code Signing Configuration"
 }
 
+variable "create_policy" {
+  type        = bool
+  default     = null
+  description = "Overrule whether the Lambda role policy has to be created"
+}
+
 variable "create_s3_dummy_object" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -21,12 +21,6 @@ variable "code_signing_config_arn" {
   description = "ARN for a Code Signing Configuration"
 }
 
-variable "create_policy" {
-  type        = bool
-  default     = null
-  description = "Overrule whether the Lambda role policy has to be created"
-}
-
 variable "create_s3_dummy_object" {
   type        = bool
   default     = true
@@ -72,6 +66,7 @@ variable "ephemeral_storage_size" {
 variable "execution_role" {
   type = object({
     additional_policy_arns = optional(set(string), [])
+    create_policy          = optional(bool)
     name_prefix            = optional(string)
     path                   = optional(string, "/")
     permissions_boundary   = optional(string)


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
Restored the variable create_policy.

**:rocket: Motivation**
When calling the lambda from a module in a module. Terraform can't always calculate the count requirement and the module fails. Returning this variable forces the module to work with the policy

**:pencil: Additional Information**
create_poliy was removed in 2.0.0, but is breaking some builds.
No breacking change
