### PR TITLE
feat: Addinv vpc_id as input variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Terraform module to create an AWS Lambda function.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.96.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.2.0 |
 
 ## Modules
 
@@ -41,7 +41,6 @@ Terraform module to create an AWS Lambda function.
 | [aws_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [archive_file.dummy](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
 ## Inputs
 
@@ -84,6 +83,7 @@ Terraform module to create an AWS Lambda function.
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the bucket | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The timeout of the lambda | `number` | `5` | no |
 | <a name="input_tracing_config_mode"></a> [tracing\_config\_mode](#input\_tracing\_config\_mode) | The lambda's AWS X-Ray tracing configuration | `string` | `null` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC where this lambda needs to run | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -43,12 +43,6 @@ resource "aws_cloudwatch_log_group" "default" {
   tags              = var.tags
 }
 
-data "aws_subnet" "selected" {
-  count = var.subnet_ids != null ? 1 : 0
-
-  id = var.subnet_ids[0]
-}
-
 resource "aws_security_group" "default" {
   #checkov:skip=CKV2_AWS_5: False positive finding, the security group is attached.
   count = var.subnet_ids != null && length(var.security_group_ids) == 0 ? 1 : 0
@@ -56,7 +50,7 @@ resource "aws_security_group" "default" {
   name        = var.security_group_name_prefix == null ? var.name : null
   name_prefix = var.security_group_name_prefix != null ? var.security_group_name_prefix : null
   description = "Security group for lambda ${var.name}"
-  vpc_id      = data.aws_subnet.selected[0].vpc_id
+  vpc_id      = var.vpc_id
   tags        = var.tags
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -281,3 +281,9 @@ variable "tracing_config_mode" {
     error_message = "If provided, allowed values are \"Active\" or \"PassThrough\"."
   }
 }
+
+variable "vpc_id" {
+  type        = string
+  default     = null
+  description = "The ID of the VPC where this lambda needs to run"
+}


### PR DESCRIPTION
- This removes the deduction of a vpc_id from the subnets id, which in some cases produced a redeployment of functions as terraform would sometimes flag the deduced value as changed

**:hammer_and_wrench: Summary**
<!--- A clear and concise description of what the PR entails. -->
<!-- Ex. I have added extra variables to be able to deploy [...] -->
I've added vpc_id as an input variable. 

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->
The current approach of deducing a vpc_id from given subnet_ids produces unwanted terraform behavior in which it flags the vpc as changed and attempts to recreate the security groups. However, the security groups are there and it fails to adapt, failing the apply run

**:pencil: Additional Information**
<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to Confluence, Microsoft Docs, or images that may help with reviewing the PR. -->
