### PR TITLE
feature: Adding vpc_id as input variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Terraform module to create an AWS Lambda function.
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.96.0 |
+|------|-------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.2.0 |
 
 ## Modules
 
@@ -84,6 +84,7 @@ Terraform module to create an AWS Lambda function.
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the bucket | `map(string)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The timeout of the lambda | `number` | `5` | no |
 | <a name="input_tracing_config_mode"></a> [tracing\_config\_mode](#input\_tracing\_config\_mode) | The lambda's AWS X-Ray tracing configuration | `string` | `null` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC where this lambda needs to run | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ locals {
   tracing_config             = var.tracing_config_mode != null ? { create : true } : {}
   vpc_config                 = var.subnet_ids != null ? { create : true } : {}
   snap_start                 = var.snap_start_apply_on != null ? { create : true } : {}
+  vpc_id                     = var.vpc_id != null ? var.vpc_id : data.aws_subnet.selected[0].vpc_id
 }
 
 module "lambda_role" {
@@ -56,7 +57,7 @@ resource "aws_security_group" "default" {
   name        = var.security_group_name_prefix == null ? var.name : null
   name_prefix = var.security_group_name_prefix != null ? var.security_group_name_prefix : null
   description = "Security group for lambda ${var.name}"
-  vpc_id      = data.aws_subnet.selected[0].vpc_id
+  vpc_id      =  local.vpc_id
   tags        = var.tags
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -281,3 +281,9 @@ variable "tracing_config_mode" {
     error_message = "If provided, allowed values are \"Active\" or \"PassThrough\"."
   }
 }
+
+variable "vpc_id" {
+  type        = string
+  default     = null
+  description = "The ID of the VPC where this lambda needs to run"
+}


### PR DESCRIPTION
This removes the deduction of a vpc_id from the subnets id, which in some cases produced a redeployment of functions as terraform would sometimes flag the deduced value as changed
🛠️ Summary

I've added vpc_id as an input variable.

🚀 Motivation

The current approach of deducing a vpc_id from given subnet_ids produces unwanted terraform behavior in which it flags the vpc as changed and attempts to recreate the security groups. However, the security groups are there and it fails to adapt, failing the apply run