### PR TITLE
fix: only retrieve vpc_id from subnet config when subnet_ids are set

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,9 @@ locals {
   tracing_config             = var.tracing_config_mode != null ? { create : true } : {}
   vpc_config                 = var.subnet_ids != null ? { create : true } : {}
   snap_start                 = var.snap_start_apply_on != null ? { create : true } : {}
-  vpc_id                     = var.vpc_id != null ? var.vpc_id : var.subnet_ids != null ? data.aws_subnet.selected[0].vpc_id : null
+  vpc_id = var.vpc_id != null ? var.vpc_id : (
+    var.subnet_ids != null ? data.aws_subnet.selected[0].vpc_id : null
+  )
 }
 
 module "lambda_role" {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

<!--- A clear and concise description of what the PR entails. -->
<!-- Ex. I have added extra variables to be able to deploy [...] -->
<!-- You can include the GitHub generated Summary, be sure to review and clean up appropriately. -->

## :rocket: Motivation

<!-- Why is this change required? What problem does it solve? -->

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
