### PR TITLE
breaking: Force Cloudwatch Loggroup to be created before the Lambda and make it mandatory

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,14 +32,12 @@ module "lambda_role" {
   tags                  = var.tags
 
   policy_arns = setunion(compact([
-    var.cloudwatch_logs ? "arn:aws:iam::aws:policy/service-role/AWSLambda${local.execution_type}ExecutionRole" : null,
+    "arn:aws:iam::aws:policy/service-role/AWSLambda${local.execution_type}ExecutionRole",
     var.tracing_config_mode != null ? "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess" : null,
   ]), var.execution_role.additional_policy_arns)
 }
 
 resource "aws_cloudwatch_log_group" "default" {
-  count = var.cloudwatch_logs ? 1 : 0
-
   name              = "/aws/lambda/${var.name}"
   kms_key_id        = var.kms_key_arn
   retention_in_days = var.log_retention

--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ resource "aws_lambda_function" "default" {
   s3_key                         = var.s3_key
   s3_object_version              = var.s3_object_version
   source_code_hash               = local.source_code_hash
-  tags                           = var.tags
+  tags                           = aws_cloudwatch_log_group.default.tags
   timeout                        = var.timeout
 
   dynamic "dead_letter_config" {

--- a/moved.tf
+++ b/moved.tf
@@ -17,3 +17,8 @@ moved {
   from = aws_iam_role_policy_attachment.enable_xray_daemon_write[0]
   to   = module.lambda_role[0].aws_iam_role_policy_attachment.default["arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"]
 }
+
+moved {
+  from = aws_cloudwatch_log_group.default[0]
+  to   = aws_cloudwatch_log_group.default
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,12 +9,6 @@ variable "architecture" {
   }
 }
 
-variable "cloudwatch_logs" {
-  type        = bool
-  default     = true
-  description = "Whether or not to configure a CloudWatch log group"
-}
-
 variable "code_signing_config_arn" {
   type        = string
   default     = null


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This PR removes the option to disable the cloudwatch log group and make the Lambda dependent on it to ensure the log group is created first.

## :rocket: Motivation

We've had to redeploy an application where the Lambda's were called during recreation. Since the Lambda throws errors when it's created (the code was not deployed yet), it created a Log Group and started writing logs to it. Resulting in Terraform throwing errors that the loggroup already exists.

So make sure that the log group exists before the Lambda.

## :pencil: Additional Information

- Made the log group mandatory, there should be no reason to disable it (opinion). Also makes the dependency easier than when it's optional
- Forced and implicit dependency to avoid having to use the `depends_on`. Only attribute that's useable are the tags, so using that. Looks weird but still better then using an explicit depends_on.
