### PR TITLE
feat: Add support for AWS Lambda Managed Instances

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ locals {
   execution_type             = var.subnet_ids == null ? "Basic" : "VPCAccess"
   filename                   = var.filename != null ? var.filename : data.archive_file.dummy.output_path
   image_config               = var.image_config != null ? { create : true } : {}
+  capacity_provider_config   = var.capacity_provider_config != null ? { create : true } : {}
   source_code_hash           = var.source_code_hash != null ? var.source_code_hash : var.filename != null ? filebase64sha256(var.filename) : null
   tracing_config             = var.tracing_config_mode != null ? { create : true } : {}
   vpc_config                 = var.subnet_ids != null ? { create : true } : {}
@@ -169,6 +170,16 @@ resource "aws_lambda_function" "default" {
 
     content {
       target_arn = var.dead_letter_target_arn
+    }
+  }
+
+  dynamic "capacity_provider_config" {
+    for_each = local.capacity_provider_config
+
+    content {
+      lambda_managed_instances_capacity_provider_config {
+        capacity_provider_arn = var.capacity_provider_config.capacity_provider_arn
+      }
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -165,14 +165,6 @@ resource "aws_lambda_function" "default" {
   tags                           = aws_cloudwatch_log_group.default.tags
   timeout                        = var.timeout
 
-  dynamic "dead_letter_config" {
-    for_each = local.dead_letter_config
-
-    content {
-      target_arn = var.dead_letter_target_arn
-    }
-  }
-
   dynamic "capacity_provider_config" {
     for_each = local.capacity_provider_config
 
@@ -185,10 +177,11 @@ resource "aws_lambda_function" "default" {
     }
   }
 
-  lifecycle {
-    precondition {
-      condition     = var.capacity_provider_config == null || var.subnet_ids == null
-      error_message = "capacity_provider_config cannot be used with subnet_ids; networking is defined on the Capacity Provider."
+  dynamic "dead_letter_config" {
+    for_each = local.dead_letter_config
+
+    content {
+      target_arn = var.dead_letter_target_arn
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -178,8 +178,17 @@ resource "aws_lambda_function" "default" {
 
     content {
       lambda_managed_instances_capacity_provider_config {
-        capacity_provider_arn = var.capacity_provider_config.capacity_provider_arn
+        capacity_provider_arn                     = var.capacity_provider_config.capacity_provider_arn
+        execution_environment_memory_gib_per_vcpu = var.capacity_provider_config.execution_environment_memory_gib_per_vcpu
+        per_execution_environment_max_concurrency = var.capacity_provider_config.per_execution_environment_max_concurrency
       }
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.capacity_provider_config == null || var.subnet_ids == null
+      error_message = "capacity_provider_config cannot be used with subnet_ids; networking is defined on the Capacity Provider."
     }
   }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.9.0"
 
   required_providers {
     aws = {

--- a/variables.tf
+++ b/variables.tf
@@ -136,7 +136,9 @@ variable "log_retention" {
 
 variable "capacity_provider_config" {
   type = object({
-    capacity_provider_arn = string
+    capacity_provider_arn                     = string
+    execution_environment_memory_gib_per_vcpu = optional(number)
+    per_execution_environment_max_concurrency = optional(number)
   })
   default     = null
   description = "Configuration for the capacity provider to use for the Lambda function"

--- a/variables.tf
+++ b/variables.tf
@@ -142,6 +142,11 @@ variable "capacity_provider_config" {
   })
   default     = null
   description = "Configuration for the capacity provider to use for the Lambda function"
+
+  validation {
+    condition     = var.capacity_provider_config == null || var.subnet_ids == null
+    error_message = "capacity_provider_config cannot be used with subnet_ids; networking is defined on the Capacity Provider."
+  }
 }
 
 variable "memory_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -147,6 +147,11 @@ variable "capacity_provider_config" {
     condition     = var.capacity_provider_config == null || var.subnet_ids == null
     error_message = "capacity_provider_config cannot be used with subnet_ids; networking is defined on the Capacity Provider."
   }
+
+  validation {
+    condition     = var.capacity_provider_config == null || var.publish
+    error_message = "When capacity_provider_config is set, publish must be set to true."
+  }
 }
 
 variable "memory_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -134,6 +134,14 @@ variable "log_retention" {
   description = "Number of days to retain log events in the specified log group"
 }
 
+variable "capacity_provider_config" {
+  type = object({
+    capacity_provider_arn = string
+  })
+  default     = null
+  description = "Configuration for the capacity provider to use for the Lambda function"
+}
+
 variable "memory_size" {
   type        = number
   default     = null


### PR DESCRIPTION
# feat: Add support for AWS Lambda Managed Instances

## Description
This PR introduces support for [AWS Lambda Managed Instances](https://aws.amazon.com/blogs/aws/introducing-aws-lambda-managed-instances-serverless-simplicity-with-ec2-flexibility/), allowing Lambda functions to be associated with an AWS Lambda Capacity Provider.

This feature enables running Lambda functions on EC2 compute resources managed by AWS, providing access to specific instance types and compute savings plans while maintaining serverless simplicity.

## How to use

To use a managed instance, provide the ARN of your Capacity Provider via the new variable. Note that when using a Capacity Provider, network configuration (VPC/Subnets) is handled by the provider, so you should ensure `subnet_ids` is not set on the Lambda module itself.